### PR TITLE
Implemented smooth zoom

### DIFF
--- a/src/main/java/com/zoomkeybinding/ZoomKeybindingConfig.java
+++ b/src/main/java/com/zoomkeybinding/ZoomKeybindingConfig.java
@@ -11,14 +11,14 @@ import java.awt.event.KeyEvent;
 public interface ZoomKeybindingConfig extends Config
 {
 	@ConfigItem(
-		position = 1,
-		keyName = "zoomIncrement",
-		name = "Zoom increment",
-		description = "The value with which the zoom value is changed on key press."
+			position = 1,
+			keyName = "zoomIncrement",
+			name = "Zoom increment",
+			description = "The value with which the zoom value is changed on key press."
 	)
 	@Range(
-		min = 0,
-		max = 800
+			min = 0,
+			max = 800
 	)
 	default int zoomIncrement() {
 		return 50;
@@ -44,5 +44,16 @@ public interface ZoomKeybindingConfig extends Config
 	default ModifierlessKeybind zoomOutKey()
 	{
 		return new ModifierlessKeybind(KeyEvent.VK_PAGE_DOWN, 0);
+	}
+
+	@ConfigItem(
+			position = 4,
+			keyName = "smoothZoom",
+			name = "Smooth zoom",
+			description = "Enable smooth zooming while holding keys. When enabled, zoom increment is divided into smaller steps for smoother motion."
+	)
+	default boolean smoothZoom()
+	{
+		return false;
 	}
 }

--- a/src/main/java/com/zoomkeybinding/ZoomKeybindingConfig.java
+++ b/src/main/java/com/zoomkeybinding/ZoomKeybindingConfig.java
@@ -3,6 +3,7 @@ package com.zoomkeybinding;
 import net.runelite.client.config.Config;
 import net.runelite.client.config.ConfigGroup;
 import net.runelite.client.config.ConfigItem;
+import net.runelite.client.config.ConfigSection;
 import net.runelite.client.config.ModifierlessKeybind;
 import net.runelite.client.config.Range;
 import java.awt.event.KeyEvent;
@@ -46,14 +47,50 @@ public interface ZoomKeybindingConfig extends Config
 		return new ModifierlessKeybind(KeyEvent.VK_PAGE_DOWN, 0);
 	}
 
+	@ConfigSection(
+			name = "Smooth Zoom",
+			description = "Options for smooth zooming",
+			position = 10
+	)
+	String smoothZoomSection = "smoothZoom";
+
 	@ConfigItem(
-			position = 4,
+			position = 11,
 			keyName = "smoothZoom",
-			name = "Smooth zoom",
-			description = "Enable smooth zooming while holding keys. When enabled, zoom increment is divided into smaller steps for smoother motion."
+			name = "Enable smooth zoom",
+			description = "Enable smooth zooming while holding keys. When enabled, zoom increment is divided into smaller steps for smoother motion.",
+			section = smoothZoomSection
 	)
 	default boolean smoothZoom()
 	{
 		return false;
+	}
+
+	@ConfigItem(
+			position = 12,
+			keyName = "separateSmoothIncrement",
+			name = "Use different increment for smooth zoom",
+			description = "Use a different increment value specifically for smooth zoom instead of dividing the regular increment.",
+			section = smoothZoomSection
+	)
+	default boolean separateSmoothIncrement()
+	{
+		return false;
+	}
+
+	@ConfigItem(
+			position = 13,
+			keyName = "smoothZoomIncrement",
+			name = "Smooth zoom increment",
+			description = "The total zoom value applied per second during smooth zoom (divided across ~60 frames per second).",
+			section = smoothZoomSection
+	)
+	@Range(
+			min = 1,
+			max = 2000
+	)
+	default int smoothZoomIncrement()
+	{
+		return 240;
 	}
 }

--- a/src/main/java/com/zoomkeybinding/ZoomKeybindingPlugin.java
+++ b/src/main/java/com/zoomkeybinding/ZoomKeybindingPlugin.java
@@ -59,7 +59,7 @@ public class ZoomKeybindingPlugin extends Plugin implements KeyListener
 	protected void shutDown() throws Exception
 	{
 		keyManager.unregisterKeyListener(this);
-		stopZooming();
+		stopSmoothZoom();
 	}
 
 	@Override
@@ -115,21 +115,17 @@ public class ZoomKeybindingPlugin extends Plugin implements KeyListener
 
 	private void handleSmoothZoomKeyPressed(KeyEvent keyEvent)
 	{
-		if (keyEvent.getKeyCode() == config.zoomInKey().getKeyCode())
+		int keyCode = keyEvent.getKeyCode();
+
+		if (keyCode == config.zoomInKey().getKeyCode() && !zoomingIn)
 		{
-			if (!zoomingIn)
-			{
-				zoomingIn = true;
-				startSmoothZoom();
-			}
+			zoomingIn = true;
+			startSmoothZoom();
 		}
-		else if (keyEvent.getKeyCode() == config.zoomOutKey().getKeyCode())
+		else if (keyCode == config.zoomOutKey().getKeyCode() && !zoomingOut)
 		{
-			if (!zoomingOut)
-			{
-				zoomingOut = true;
-				startSmoothZoom();
-			}
+			zoomingOut = true;
+			startSmoothZoom();
 		}
 	}
 
@@ -140,7 +136,7 @@ public class ZoomKeybindingPlugin extends Plugin implements KeyListener
 			zoomingIn = false;
 			if (!zoomingOut)
 			{
-				stopZooming();
+				stopSmoothZoom();
 			}
 		}
 		else if (keyEvent.getKeyCode() == config.zoomOutKey().getKeyCode())
@@ -148,7 +144,7 @@ public class ZoomKeybindingPlugin extends Plugin implements KeyListener
 			zoomingOut = false;
 			if (!zoomingIn)
 			{
-				stopZooming();
+				stopSmoothZoom();
 			}
 		}
 	}
@@ -189,11 +185,12 @@ public class ZoomKeybindingPlugin extends Plugin implements KeyListener
 		}, 0, ZOOM_UPDATE_INTERVAL_MS, TimeUnit.MILLISECONDS);
 	}
 
-	private void stopZooming()
+	private void stopSmoothZoom()
 	{
 		if (zoomTask != null && !zoomTask.isDone())
 		{
 			zoomTask.cancel(false);
 		}
+		zoomTask = null;
 	}
 }

--- a/src/main/java/com/zoomkeybinding/ZoomKeybindingPlugin.java
+++ b/src/main/java/com/zoomkeybinding/ZoomKeybindingPlugin.java
@@ -1,9 +1,11 @@
 package com.zoomkeybinding;
+
 import com.google.inject.Provides;
-
 import java.awt.event.KeyEvent;
+import java.util.concurrent.ScheduledExecutorService;
+import java.util.concurrent.ScheduledFuture;
+import java.util.concurrent.TimeUnit;
 import javax.inject.Inject;
-
 import net.runelite.api.Client;
 import net.runelite.api.ScriptID;
 import net.runelite.api.VarClientInt;
@@ -15,10 +17,13 @@ import net.runelite.client.plugins.Plugin;
 import net.runelite.client.plugins.PluginDescriptor;
 
 @PluginDescriptor(
-	name = "Zoom keybinding"
+		name = "Zoom keybinding"
 )
 public class ZoomKeybindingPlugin extends Plugin implements KeyListener
 {
+	private static final int ZOOM_UPDATE_INTERVAL_MS = 16; // ~60 FPS
+	private static final int SMOOTH_ZOOM_DIVISOR = 8; // Divides config increment for smooth updates
+
 	@Inject
 	private Client client;
 
@@ -27,9 +32,16 @@ public class ZoomKeybindingPlugin extends Plugin implements KeyListener
 
 	@Inject
 	private ZoomKeybindingConfig config;
-	
+
 	@Inject
 	private KeyManager keyManager;
+
+	@Inject
+	private ScheduledExecutorService scheduledExecutorService;
+
+	private ScheduledFuture<?> zoomTask;
+	private boolean zoomingIn = false;
+	private boolean zoomingOut = false;
 
 	@Provides
 	ZoomKeybindingConfig provideConfig(ConfigManager configManager)
@@ -47,26 +59,141 @@ public class ZoomKeybindingPlugin extends Plugin implements KeyListener
 	protected void shutDown() throws Exception
 	{
 		keyManager.unregisterKeyListener(this);
+		stopZooming();
 	}
 
 	@Override
-	public void keyPressed(KeyEvent e) {
-		int increment = 0;
-		if (e.getKeyCode() == config.zoomInKey().getKeyCode()) {
-			increment = config.zoomIncrement();
-		} else if (e.getKeyCode() == config.zoomOutKey().getKeyCode()) {
-			increment = -config.zoomIncrement();
+	public void keyPressed(KeyEvent keyEvent)
+	{
+		if (config.smoothZoom())
+		{
+			handleSmoothZoomKeyPressed(keyEvent);
+		}
+		else
+		{
+			handleRegularZoomKeyPressed(keyEvent);
+		}
+	}
+
+	@Override
+	public void keyReleased(KeyEvent keyEvent)
+	{
+		if (config.smoothZoom())
+		{
+			handleSmoothZoomKeyReleased(keyEvent);
+		}
+		// Regular zoom doesn't need keyReleased handling
+	}
+
+	@Override
+	public void keyTyped(KeyEvent keyEvent)
+	{
+		// Not used
+	}
+
+	private void handleRegularZoomKeyPressed(KeyEvent keyEvent)
+	{
+		int zoomIncrement = 0;
+		if (keyEvent.getKeyCode() == config.zoomInKey().getKeyCode())
+		{
+			zoomIncrement = config.zoomIncrement();
+		}
+		else if (keyEvent.getKeyCode() == config.zoomOutKey().getKeyCode())
+		{
+			zoomIncrement = -config.zoomIncrement();
 		}
 
-		final int zoomValue = client.getVarcIntValue(VarClientInt.CAMERA_ZOOM_FIXED_VIEWPORT) + increment;
-		clientThread.invokeLater(() -> client.runScript(ScriptID.CAMERA_DO_ZOOM, zoomValue, zoomValue));
-	}
-	
-	@Override
-	public void keyReleased(KeyEvent e) {
+		if (zoomIncrement != 0)
+		{
+			final int currentZoomValue = client.getVarcIntValue(VarClientInt.CAMERA_ZOOM_FIXED_VIEWPORT);
+			final int newZoomValue = currentZoomValue + zoomIncrement;
+			clientThread.invokeLater(() ->
+					client.runScript(ScriptID.CAMERA_DO_ZOOM, newZoomValue, newZoomValue)
+			);
+		}
 	}
 
-	@Override
-	public void keyTyped(KeyEvent e) {
+	private void handleSmoothZoomKeyPressed(KeyEvent keyEvent)
+	{
+		if (keyEvent.getKeyCode() == config.zoomInKey().getKeyCode())
+		{
+			if (!zoomingIn)
+			{
+				zoomingIn = true;
+				startSmoothZoom();
+			}
+		}
+		else if (keyEvent.getKeyCode() == config.zoomOutKey().getKeyCode())
+		{
+			if (!zoomingOut)
+			{
+				zoomingOut = true;
+				startSmoothZoom();
+			}
+		}
+	}
+
+	private void handleSmoothZoomKeyReleased(KeyEvent keyEvent)
+	{
+		if (keyEvent.getKeyCode() == config.zoomInKey().getKeyCode())
+		{
+			zoomingIn = false;
+			if (!zoomingOut)
+			{
+				stopZooming();
+			}
+		}
+		else if (keyEvent.getKeyCode() == config.zoomOutKey().getKeyCode())
+		{
+			zoomingOut = false;
+			if (!zoomingIn)
+			{
+				stopZooming();
+			}
+		}
+	}
+
+	private void startSmoothZoom()
+	{
+		if (zoomTask != null && !zoomTask.isDone())
+		{
+			return; // Already zooming
+		}
+
+		zoomTask = scheduledExecutorService.scheduleAtFixedRate(() ->
+		{
+			if (!zoomingIn && !zoomingOut)
+			{
+				return;
+			}
+
+			int zoomIncrementPerUpdate = Math.max(1, config.zoomIncrement() / SMOOTH_ZOOM_DIVISOR);
+			int totalZoomIncrement = 0;
+
+			if (zoomingIn)
+			{
+				totalZoomIncrement += zoomIncrementPerUpdate;
+			}
+			if (zoomingOut)
+			{
+				totalZoomIncrement -= zoomIncrementPerUpdate;
+			}
+
+			final int currentZoomValue = client.getVarcIntValue(VarClientInt.CAMERA_ZOOM_FIXED_VIEWPORT);
+			final int newZoomValue = currentZoomValue + totalZoomIncrement;
+
+			clientThread.invokeLater(() ->
+					client.runScript(ScriptID.CAMERA_DO_ZOOM, newZoomValue, newZoomValue)
+			);
+
+		}, 0, ZOOM_UPDATE_INTERVAL_MS, TimeUnit.MILLISECONDS);
+	}
+
+	private void stopZooming()
+	{
+		if (zoomTask != null && !zoomTask.isDone())
+		{
+			zoomTask.cancel(false);
+		}
 	}
 }

--- a/src/main/java/com/zoomkeybinding/ZoomKeybindingPlugin.java
+++ b/src/main/java/com/zoomkeybinding/ZoomKeybindingPlugin.java
@@ -23,6 +23,7 @@ public class ZoomKeybindingPlugin extends Plugin implements KeyListener
 {
 	private static final int ZOOM_UPDATE_INTERVAL_MS = 16; // ~60 FPS
 	private static final int SMOOTH_ZOOM_DIVISOR = 8; // Divides config increment for smooth updates
+	private static final int FRAMES_PER_SECOND = 60;
 
 	@Inject
 	private Client client;
@@ -149,6 +150,20 @@ public class ZoomKeybindingPlugin extends Plugin implements KeyListener
 		}
 	}
 
+	private int getSmoothZoomIncrementPerUpdate()
+	{
+		if (config.separateSmoothIncrement())
+		{
+			// Use separate smooth increment, divide by FPS to get per-frame increment
+			return Math.max(1, config.smoothZoomIncrement() / FRAMES_PER_SECOND);
+		}
+		else
+		{
+			// Use regular increment divided by divisor (original behavior)
+			return Math.max(1, config.zoomIncrement() / SMOOTH_ZOOM_DIVISOR);
+		}
+	}
+
 	private void startSmoothZoom()
 	{
 		if (zoomTask != null && !zoomTask.isDone())
@@ -163,7 +178,7 @@ public class ZoomKeybindingPlugin extends Plugin implements KeyListener
 				return;
 			}
 
-			int zoomIncrementPerUpdate = Math.max(1, config.zoomIncrement() / SMOOTH_ZOOM_DIVISOR);
+			int zoomIncrementPerUpdate = getSmoothZoomIncrementPerUpdate();
 			int totalZoomIncrement = 0;
 
 			if (zoomingIn)


### PR DESCRIPTION
## Add Smooth Zoom Option for Continuous Zooming 🎯

Hey! I've been using this plugin and it's fantastic, really appreciate the work you've put into it! 

### The Issue
I noticed that the current zoom can feel a bit choppy since it jumps by discrete amounts on each key press. It's especially noticeable when you want to zoom quickly but smoothly (like when you have a broken mouse wheel 😅).

### What I Added
I've implemented an optional **Smooth Zoom** feature that lets you zoom continuously while holding the keys. 

### Changes Made
- Added a new `smoothZoom` config option (defaults to `false` so nothing changes for current users)
- When enabled, holding zoom keys creates smooth continuous zooming at 60 FPS
- The smooth zoom still respects your `zoomIncrement` setting - it just spreads it across multiple frames
- All the original functionality stays exactly the same when smooth zoom is off

### How It Works
- **Regular Mode**: Works exactly like before - press key, get instant zoom
- **Smooth Mode**: Hold key down for continuous smooth zooming (like having a working mouse wheel!)

### Why This is Cool
- Zero breaking changes - existing users won't even notice unless they want to try it
- Gives players the choice between quick discrete jumps or smooth scrolling
- Perfect for people with hardware issues
- Uses the same increment value, so it feels consistent with your existing settings

I've tested it pretty thoroughly and it feels great to use. Would love to hear your thoughts! Happy to make any adjustments you'd like.

Thanks again for such a useful plugin! Best regards, Paul.